### PR TITLE
Update to 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - pip
   run:
     - python
-    - anaconda-client >=1.12.0
     - readchar
     - rich
     - typer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cli-base" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cli_base-{{ version }}.tar.gz
-  sha256: d08c31755952b0a5c267a80f229e9205d0ad8527020629ab2394e367372302d6
+  sha256: fd0ef7cf48b98e87f52bde3f632aa58a5ab600b8c11b3f0a5a663a369d8a2e10
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - hatchling
     - hatch-vcs >=0.3
-    - setuptools-scm >=7.1
     - pip
   run:
     - python


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [TULZ-929](https://anaconda.atlassian.net/browse/TULZ-929) 
- [Upstream repository](https://github.com/anaconda/anaconda-cloud-tools)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-cloud-tools/releases/tag/anaconda-cli-base-v0.2.2)

### Explanation of changes:

- Drop `anaconda-client` dependency in `anaconda-cli-base`. This has been moved to a more appropriate location inside `anaconda-cloud-cli` where it belongs.


[TULZ-929]: https://anaconda.atlassian.net/browse/TULZ-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

We should merge this after we merge `anaconda-cloud-cli-v0.2.0`: https://github.com/AnacondaRecipes/anaconda-cloud-cli-feedstock/pull/2