### PR TITLE
Update to 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cli-base" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cli_base-{{ version }}.tar.gz
-  sha256: d08c31755952b0a5c267a80f229e9205d0ad8527020629ab2394e367372302d6
+  sha256: fd0ef7cf48b98e87f52bde3f632aa58a5ab600b8c11b3f0a5a663a369d8a2e10
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true # [py<38]
 
 requirements:
   host:
@@ -22,7 +23,6 @@ requirements:
     - pip
   run:
     - python
-    - anaconda-client >=1.12.0
     - readchar
     - rich
     - typer
@@ -32,7 +32,7 @@ test:
     - anaconda_cli_base
   commands:
     - python -c "from anaconda_cli_base import __version__; assert __version__ == \"{{ version }}\""
-    #- pip check # anaconda-anon-usage 0.4.3 requires conda, which is not installed.
+    - pip check
   requires:
     - pip
 
@@ -43,6 +43,8 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
+  dev_url: https://pypi.org/project/anaconda-cli-base/
+  doc_url: https://pypi.org/project/anaconda-cli-base/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
anaconda-cli-base 0.2.2
ticket specifically requests 0.2.2

**Destination channel:** main

### Links

- Ticket: https://anaconda.atlassian.net/browse/PKG-4375
- Source: https://inspector.pypi.io/project/anaconda-cli-base/0.2.2/packages/37/7e/cb0ad305790904b1b43097534a99e02f3028726697789efc2c7a5ca94ab3/anaconda_cli_base-0.2.2.tar.gz/anaconda_cli_base-0.2.2/pyproject.toml
- Relevant PRs: https://github.com/AnacondaRecipes/anaconda-cli-base-feedstock/pull/2

### Explanation of changes:
- Follow changes from PR2.
