### PR TITLE
0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cli-base" %}
-{% set version = "0.4.1" %}
+{% set version = "0.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cli_base-{{ version }}.tar.gz
-  sha256: 59e50f43f174a8f6d9b7754bfcb4eb7b69f5540a1108232edfbaf8a32f43be54
+  sha256: 009fda4592daf5a7c47d354b23af3226d02fa8b8a06dc685ab11ade7ba68c721
 
 build:
-  number: 1
+  number: 0
   skip: true # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -30,6 +30,7 @@ requirements:
     - readchar
     - rich
     - typer
+    - tomli
   run_constrained:
       # Ensure that a version of anaconda-cli-base cannot be installed if an incompatible
       # older version of anaconda-client is installed.


### PR DESCRIPTION
anaconda-cli-base 0.4.2

**Destination channel:**  defaults

### Links

- [PKG-6925](https://anaconda.atlassian.net/browse/PKG-6925) 
- [Upstream repository](https://github.com/anaconda/anaconda-cli-base/releases/tag/v0.4.2)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-cli-base/releases/tag/v0.4.2)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- update version and add dep


[PKG-6925]: https://anaconda.atlassian.net/browse/PKG-6925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ