### PR TITLE
Update to 0.5.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-cli-base" %}
-{% set version = "0.4.2" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/anaconda_cli_base-{{ version }}.tar.gz
-  sha256: 009fda4592daf5a7c47d354b23af3226d02fa8b8a06dc685ab11ade7ba68c721
+  sha256: 96ba616ae7091ef2cb5bd473dc164c68e2328ba98b70ce5afbfe7ad3123c8081
 
 build:
   number: 0


### PR DESCRIPTION
anaconda-cli-base 0.5.2

**Destination channel:** {defaults}

### Links

- [PKG-7280](https://anaconda.atlassian.net/browse/PKG-7280) 
- [Upstream repository](https://pypi.org/project/anaconda-cli-base/)
- Related PRs:
  - anaconda-cloud-auth
  - conda-token

[PKG-7280]: https://anaconda.atlassian.net/browse/PKG-7280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ