### PR TITLE
anaconda-cli-base 0.6.0: Rebuild for py314 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314: yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pydantic-settings-feedstock/pr4/e9ecca0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314: yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pydantic-settings-feedstock/pr4/e9ecca0
-  - https://staging.continuum.io/pbp/fs/typer-feedstock/pr6/e46e56b
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/pbp/fs/pydantic-settings-feedstock/pr4/e9ecca0
+  - https://staging.continuum.io/pbp/fs/typer-feedstock/pr6/e46e56b
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-windows-path-fix.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,7 @@ requirements:
   run:
     - python
     - click <8.2
-    - pydantic-settings >=2.3 # [py<314]
-    - pydantic-settings >=2.12.0 # [py==314]
+    - pydantic-settings >=2.3
     - readchar
     - rich
     - typer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
   run:
     - python
     - click <8.2
-    - pydantic-settings >=2.3
+    - pydantic-settings >=2.3 # [py<314]
+    - pydantic-settings >=2.12.0 # [py==314]
     - readchar
     - rich
     - typer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,10 @@ requirements:
     - pydantic-settings >=2.3
     - readchar
     - rich
-    - typer
+    # conda-build can install typer <0.6.0, but it's not compatible with anaconda-cli-base:
+    # TypeError: Typer.__init__() got an unexpected keyword argument 'pretty_exceptions_enable'
+    # pretty_exceptions_enable was added in typer 0.6.0, see https://github.com/fastapi/typer/commit/c750f8206e75af3ee963b1d6bc9b9a887be7f4f7
+    - typer >=0.6.0
     - tomli
     - packaging >=23.0
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,10 +31,7 @@ requirements:
     - pydantic-settings >=2.3
     - readchar
     - rich
-    # conda-build can install typer <0.6.0, but it's not compatible with anaconda-cli-base:
-    # TypeError: Typer.__init__() got an unexpected keyword argument 'pretty_exceptions_enable'
-    # pretty_exceptions_enable was added in typer 0.6.0, see https://github.com/fastapi/typer/commit/c750f8206e75af3ee963b1d6bc9b9a887be7f4f7
-    - typer >=0.6.0
+    - typer
     - tomli
     - packaging >=23.0
   run_constrained:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10922) 
- [Upstream repository](https://inspector.pypi.io/project/anaconda-cli-base/0.6.0/packages/29/8a/4c9d6ba8ff13ba4fcc2b4f625d4c4896001f894912490c52008e5c7237d5/anaconda_cli_base-0.6.0.tar.gz/)

### Explanation of changes:

- 

### Notes:

- Rebuild with a newer pydantic-settings https://github.com/AnacondaRecipes/pydantic-settings-feedstock/pull/4, which supports py314